### PR TITLE
chore: remove Parallel

### DIFF
--- a/apullo.gemspec
+++ b/apullo.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mem", "~> 0.1"
   spec.add_dependency "murmurhash3", "~> 0.1"
   spec.add_dependency "oga", "~> 2.15"
-  spec.add_dependency "parallel", "~> 1.18"
   spec.add_dependency "public_suffix", "~> 4.0"
   spec.add_dependency "ssh_scan", "~> 0.0"
   spec.add_dependency "thor", "~> 0.20"

--- a/lib/apullo/cli.rb
+++ b/lib/apullo/cli.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "json"
-require "parallel"
 require "thor"
 
 module Apullo
@@ -27,7 +26,7 @@ module Apullo
           }
         end
 
-        Parallel.map(Apullo.fingerprints) do |klass|
+        Apullo.fingerprints.map do |klass|
           fingerprint = klass.new(target)
           fingerprint.headers = headers if fingerprint.respond_to?(:headers=)
 


### PR DESCRIPTION
Remove Parallel because it causes erros when dealing with HTTPS websites